### PR TITLE
Fix precision loss in transaction amounts

### DIFF
--- a/api/transactions.py
+++ b/api/transactions.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import HTTPException
 
 from core.security import get_api_key
 from models.transaction import Transaction

--- a/api/transactions.py
+++ b/api/transactions.py
@@ -1,6 +1,6 @@
-from fastapi import APIRouter
-from fastapi import Depends
-from fastapi import HTTPException
+from decimal import Decimal
+
+from fastapi import APIRouter, Depends, HTTPException
 
 from core.security import get_api_key
 from models.transaction import Transaction
@@ -14,7 +14,7 @@ def add_transaction(transaction: Transaction):
     try:
         actual_service.add_transaction(
             account=transaction.account,
-            amount=transaction.amount * -1,
+            amount=transaction.amount * Decimal(-1),
             date=transaction.date,
             payee=transaction.payee,
             notes=transaction.notes,

--- a/models/transaction.py
+++ b/models/transaction.py
@@ -1,13 +1,13 @@
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel
-from pydantic import validator
+from pydantic import BaseModel, Field, validator
 
 
 class Transaction(BaseModel):
     account: str = ""
-    amount: Optional[float] = 0
+    amount: Optional[Decimal] = Field(default=Decimal(0), decimal_places=2)
     date: Optional[str] = datetime.now().strftime("%b %d, %Y")
     payee: Optional[str] = ""
     notes: Optional[str] = ""
@@ -16,5 +16,5 @@ class Transaction(BaseModel):
     @validator("amount", pre=True)
     def empty_str_to_zero(cls, v):
         if v == "":
-            return 0
+            return Decimal(0)
         return v

--- a/models/transaction.py
+++ b/models/transaction.py
@@ -2,7 +2,9 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel
+from pydantic import Field
+from pydantic import validator
 
 
 class Transaction(BaseModel):


### PR DESCRIPTION
**Issue:**
Precision is being lost when handling certain transaction amounts, specifically those ending in 9. This issue stems from the inherent limitations of floating-point representation in binary computers. As an example:
- A transaction amount of $22.99 was input.
- When multiplied by -1 (to convert from debit to credit or vice versa), the result became 
-22.989999999999999857891452847979962825775146484375.
- This was then rounded to -22.98, effectively losing one cent.

![image](https://github.com/user-attachments/assets/d898b36e-bbbd-4699-b33c-86eeda21e6f6)

**Solution:**
To address this, switch from the use of floating-point (Float) to Decimal for representing monetary values. The Decimal type provides exact decimal representation and arithmetic, eliminating precision issues.

**Changes:**
- Updated Transaction model to use Decimal instead of float for the 'amount' field
- Updated `/transaction` route to use Decimal