### PR TITLE
Update setup for Python 3.12+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 
-from setuptools import find_packages, setup
+from setuptools import find_packages
+from setuptools import setup
 
 # User-friendly description from README.md
 current_directory = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
-from distutils.core import setup
 
-from setuptools import find_packages
+from setuptools import find_packages, setup
 
 # User-friendly description from README.md
 current_directory = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
**Issue:**
`distutils` is deprecated with removal planned for Python 3.12
Further information can be found here: https://docs.python.org/3.11/library/distutils.html

**Solution:**
Use `setup()` from `setuptools` rather than `distutils.core`