### PR TITLE
Add support for encrypted budget files

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -4,6 +4,8 @@ api_key: "527D6AAA-B22A-4D48-9DC8-C203139E5531"
 actual_url: "https://actual.yourdomain.com"
 # Password for your Actual Budget Server
 actual_password: "superSecretPassword"
+# Encryption passwordAdd commentMore actions
+actual_encryption_password: "None" # or "superSecretEncryptionPassword"
 # The name of your budget or Sync ID of the budget
 actual_budget: "My budget"
 # The Unique Id of an account you want transactions to default too

--- a/core/config.py
+++ b/core/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     api_key: str
     actual_url: str
     actual_password: str
+    actual_encryption_password: str
     actual_budget: str
     actual_default_account_id: str
     actual_backup_payee: str

--- a/services/actual_service.py
+++ b/services/actual_service.py
@@ -26,6 +26,7 @@ class ActualService:
         with Actual(
             settings.actual_url,
             password=settings.actual_password,
+            encryption_password=settings.actual_encryption_password,
             file=settings.actual_budget,
         ) as actual:
             for tx in transactions:


### PR DESCRIPTION
Added a few lines of code to enable support for encrypted budget files as mentioned in #85. 

Tested the changes with both encrypted and unencrypted budgets and all was working well for me on the latest version of actual server.