### PR TITLE
feat: single budgets schema with multi-budget routing and per-account top-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,45 @@ Actual Tap uses FastAPI that utilises the <a href="https://github.com/bvanelli/a
 
 The primary purpose of Actual Tap is receive a POST request from mobile devices _(.e.g iOS Shortcuts)_ when a Tap to Pay transaction is made. Once the POST request is received Actual Tap will POST the Name and Amount to Actual Budget.
 
-In addition, there is a sample <a href="config/config.yml.sample">configuration file</a> that allows you to map between the Tap to Pay account and your Actual Account ID. It can be used as a template to create your own config.yml within the same directory.
+In addition, there is a sample <a href="config/config.yml.sample">configuration file</a> that maps Tap to Pay cards to your Actual accounts. It can be used as a template to create your own config.yml within the same directory.
+
+### Configuration: budgets
+
+All routing lives under a single `budgets:` list. Each budget is identified by its name or Sync ID and carries its own `account_mappings` (card name → Actual account). The card used for a payment decides which budget/Sync ID is opened, so different cards can land in different budgets automatically — useful if you keep e.g. a personal and a shared budget.
+
+Mark exactly **one** budget with `default: true`: cards not mapped in any budget go there, using its `default_account_id`.
+
+```yaml
+budgets:
+  - name_or_sync_id: "My budget"
+    default: true
+    default_account_id: "8AF657D4-4811-42C7-8272-E299A8DAC43A"
+    account_mappings:
+      "Personal Card": "b15d14ce-c0d0-40a8-95ac-45fc6681f420"
+      "Trade Republic":
+        account_id: "D4E9A36B-1C8E-4D2A-9F6B-1A2B3C4D5E6F"
+        topup: 1
+  - name_or_sync_id: "Shared budget"
+    account_mappings:
+      "Joint Card": "C3D8F25A-9C7D-4C9B-8589-8A3790C03B2D"
+```
+
+Each account value is either a plain UUID string (no top-up) or an object `{ account_id, topup }`.
+
+### Top-up accounts (Trade Republic style)
+
+Some cards (e.g. Trade Republic) are "topped up" in whole euros, so a €1.20 spend actually removes €2.00 from your balance. Enable it per account with the object form shown above.
+
+The amount recorded in Actual is rounded up to the next euro and the rounding remainder is multiplied by `topup` (whole-euro amounts add `topup` euros instead). The original amount is preserved in the transaction notes.
+
+| Amount | topup 1 | topup 2 | topup 3 |
+| ------ | ------- | ------- | ------- |
+| 1.00   | 2.00    | 3.00    | 4.00    |
+| 1.20   | 2.00    | 2.80    | 3.60    |
+| 2.30   | 3.00    | 3.70    | 4.40    |
+| 7.50   | 8.00    | 8.50    | 9.00    |
+
+`topup: 0` (or omitting it / using the plain string form) disables the feature.
 
 Ideal flow:
 

--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -6,18 +6,47 @@ actual_url: "https://actual.yourdomain.com"
 actual_password: "superSecretPassword"
 # Encryption password (Optional)
 actual_encryption_password: "superSecretEncryptionPassword"
-# The name of your budget or Sync ID of the budget
-actual_budget: "My budget"
-# The Unique Id of an account you want transactions to default too
-actual_default_account_id: "8AF657D4-4811-42C7-8272-E299A8DAC43A"
 # If the Merchant name is missing, but the Amount still has a value, a transaction can be created with this as the payee name
 actual_backup_payee: "Unknown"
-# Mapping of Tap to Pay account to Actual Account ID:
-# For iOS users, the account key is the exact, case-sensitive name of the card found under "Card Details" within the Wallet App.
-# The account ID is the UUID found in the URL with the account selected in Actual. It is not case-sensitive.
-account_mappings:
-  "Sample Credit Card": "b15d14ce-c0d0-40a8-95ac-45fc6681f420"
-  savings: "8AF657D4-4811-42C7-8272-E299A8DAC43A"
-  checking: "B2F7DF53-6A9C-42CF-B091-9129A3A9B528"
-  credit_card: "C3D8F25A-9C7D-4C9B-8589-8A3790C03B2D"
+
+# All routing lives here. Each budget is identified by its name or Sync ID
+# and carries its own account mappings. The card name (account) used for a
+# Tap-to-Pay payment decides which budget is opened, so different cards can
+# land in different budgets automatically.
+#
+# - Mark exactly one budget with `default: true`. Cards not mapped in any
+#   budget go there, using its `default_account_id`.
+# - For iOS users, the account key is the exact, case-sensitive name of the
+#   card found under "Card Details" within the Wallet App.
+# - The account ID is the UUID found in the URL with the account selected
+#   in Actual. It is not case-sensitive.
+#
+# Each account value can be either:
+#   - a plain UUID string (no top-up), or
+#   - an object: { account_id: "<uuid>", topup: <N> }
+#
+# Top-up (N) emulates a Trade-Republic-style top-up card: the spend is
+# rounded up to the next whole euro and the rounding remainder is
+# multiplied by N. If the amount is already a whole euro, N euros are
+# added. Examples with topup 1: 1.00 -> 2.00, 1.20 -> 2.00, 2.30 -> 3.00.
+# Examples with topup 2: 1.00 -> 3.00, 1.20 -> 2.80, 2.30 -> 3.70.
+# topup: 0 (or omitting it / using the plain string form) disables it.
+budgets:
+  - name_or_sync_id: "My budget"
+    default: true
+    default_account_id: "8AF657D4-4811-42C7-8272-E299A8DAC43A"
+    account_mappings:
+      "Sample Credit Card": "b15d14ce-c0d0-40a8-95ac-45fc6681f420"
+      savings: "8AF657D4-4811-42C7-8272-E299A8DAC43A"
+      checking: "B2F7DF53-6A9C-42CF-B091-9129A3A9B528"
+      credit_card: "C3D8F25A-9C7D-4C9B-8589-8A3790C03B2D"
+      # Example with top-up enabled (Trade Republic style, 1x):
+      "Trade Republic":
+        account_id: "D4E9A36B-1C8E-4D2A-9F6B-1A2B3C4D5E6F"
+        topup: 1
+  # Add more budgets / Sync IDs as needed:
+  - name_or_sync_id: "Shared budget"
+    account_mappings:
+      "Joint Card": "C3D8F25A-9C7D-4C9B-8589-8A3790C03B2D"
+
 log_level: INFO

--- a/core/config.py
+++ b/core/config.py
@@ -1,10 +1,77 @@
 from pathlib import Path
 from typing import Dict
+from typing import List
 from typing import Optional
 
 import yaml
+from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import field_validator
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
+
+
+class AccountMapping(BaseModel):
+    """A single Tap-to-Pay account mapping.
+
+    ``account_id`` is the Actual account UUID. ``topup`` is the top-up
+    multiplier for that account (0 = disabled). See ``apply_topup`` in
+    ``services.actual_service`` for the exact math.
+    """
+
+    account_id: str
+    topup: int = 0
+
+    @field_validator("topup", mode="before")
+    def validate_topup(cls, v):
+        if v is None or v == "":
+            return 0
+        try:
+            topup = int(v)
+        except (TypeError, ValueError):
+            raise ValueError("topup must be an integer (0 = disabled, 1 = 1x, 2 = 2x, ...)")
+        if topup < 0:
+            raise ValueError("topup cannot be negative")
+        return topup
+
+
+def _coerce_account_mappings(mappings):
+    """Normalize a mapping dict so values become ``AccountMapping``.
+
+    Accepts the short ``"Card Name": "uuid"`` form as well as the explicit
+    ``"Card Name": {account_id: "uuid", topup: 1}`` form.
+    """
+    if not mappings:
+        return {}
+    normalized = {}
+    for name, value in mappings.items():
+        if isinstance(value, AccountMapping):
+            normalized[name] = value
+        elif isinstance(value, str):
+            normalized[name] = AccountMapping(account_id=value)
+        elif isinstance(value, dict):
+            normalized[name] = AccountMapping(**value)
+        else:
+            raise ValueError(f"Invalid account mapping for '{name}'. Expected a UUID string or an object with 'account_id'.")
+    return normalized
+
+
+class BudgetConfig(BaseModel):
+    """A budget (by name or Sync ID) with its own account mappings.
+
+    Set ``default: true`` on exactly one budget to make it receive cards
+    that are not mapped anywhere; that budget's ``default_account_id`` is
+    used for them.
+    """
+
+    name_or_sync_id: str
+    default: bool = False
+    default_account_id: Optional[str] = None
+    account_mappings: Dict[str, AccountMapping] = {}
+
+    @field_validator("account_mappings", mode="before")
+    def coerce_mappings(cls, v):
+        return _coerce_account_mappings(v)
 
 
 class Settings(BaseSettings):
@@ -14,11 +81,34 @@ class Settings(BaseSettings):
     actual_url: str
     actual_password: str
     actual_encryption_password: Optional[str] = None
-    actual_budget: str
-    actual_default_account_id: str
     actual_backup_payee: str
-    account_mappings: Dict[str, str]
+    # The only routing structure. Every budget has its own account
+    # mappings; one budget may set ``default: true`` to absorb unmapped
+    # cards via its ``default_account_id``.
+    budgets: List[BudgetConfig]
     log_level: str = "INFO"
+
+    @field_validator("budgets")
+    def budgets_not_empty(cls, v):
+        if not v:
+            raise ValueError("At least one budget must be configured under 'budgets'.")
+        return v
+
+    @model_validator(mode="after")
+    def validate_default_budget(self):
+        defaults = [b for b in self.budgets if b.default]
+        if len(defaults) > 1:
+            raise ValueError("Only one budget can be marked as 'default: true'.")
+        if defaults and not defaults[0].default_account_id:
+            raise ValueError("The default budget must define 'default_account_id'.")
+        return self
+
+    @property
+    def default_budget(self) -> Optional[BudgetConfig]:
+        for budget in self.budgets:
+            if budget.default:
+                return budget
+        return None
 
 
 # Define config_path globally

--- a/services/actual_service.py
+++ b/services/actual_service.py
@@ -7,10 +7,14 @@ from decimal import Decimal
 from typing import List
 
 from actual import Actual
+from actual.database import Transactions
 from actual.queries import create_transaction
 from actual.queries import get_payees
 from actual.queries import get_ruleset
+from sqlalchemy import func
 from sqlalchemy.orm.exc import MultipleResultsFound
+from sqlmodel import col
+from sqlmodel import select
 
 from core.config import AccountMapping
 from core.config import settings
@@ -66,10 +70,9 @@ class ActualService:
         self.client = None
 
     @staticmethod
-    def _build_import_id(account_id: str, amount: Decimal, date, payee: str, notes: str, cleared: bool) -> str:
+    def _build_import_id(account_id: str, amount: Decimal, date, payee: str, cleared: bool) -> str:
         normalized_amount = format(amount.normalize(), "f")
         normalized_payee = (payee or "").strip().lower()
-        normalized_notes = (notes or "").strip().lower()
         cleared_flag = "1" if cleared else "0"
         raw_key = json.dumps(
             [
@@ -77,7 +80,6 @@ class ActualService:
                 normalized_amount,
                 date.isoformat(),
                 normalized_payee,
-                normalized_notes,
                 cleared_flag,
             ],
             separators=(",", ":"),
@@ -96,6 +98,19 @@ class ActualService:
         if not matching_payees:
             return None
         return matching_payees[0]
+
+    @staticmethod
+    def _find_existing_by_imported_id(session, account_id: str, imported_id: str):
+        # Strict imported_id dedup, scoped to the account and excluding
+        # tombstoned rows. We deliberately avoid actualpy's reconcile fuzzy
+        # match (±7 days same amount) because identical repeated spends
+        # (e.g. same daily coffee) would otherwise collapse into one.
+        query = select(Transactions).where(
+            Transactions.acct == account_id,
+            col(Transactions.financial_id) == imported_id,
+            func.coalesce(Transactions.tombstone, 0) == 0,
+        )
+        return session.exec(query).first()
 
     @staticmethod
     def _unpack_mapping(value):
@@ -184,7 +199,6 @@ class ActualService:
                         amount=amount,
                         date=date,
                         payee=payee,
-                        notes=notes,
                         cleared=tx.cleared,
                     )
 
@@ -203,6 +217,15 @@ class ActualService:
                         "Cleared": tx.cleared,
                     }
                     transaction_info_list.append(transaction_info)
+
+                    # Idempotency: if a transaction with the same imported_id
+                    # already exists in this account, skip it. Autoflush makes
+                    # this work within the same batch too.
+                    existing = self._find_existing_by_imported_id(actual.session, account_id, import_id)
+                    if existing is not None:
+                        logger.info(f"Skipping duplicate transaction for imported_id={import_id} (existing id={existing.id})")
+                        transaction_info["Deduped"] = True
+                        continue
 
                     # Create transaction in Actual
                     try:

--- a/services/actual_service.py
+++ b/services/actual_service.py
@@ -1,5 +1,8 @@
 import hashlib
 import json
+from collections import OrderedDict
+from decimal import ROUND_CEILING
+from decimal import ROUND_HALF_UP
 from decimal import Decimal
 from typing import List
 
@@ -9,12 +12,53 @@ from actual.queries import get_payees
 from actual.queries import get_ruleset
 from sqlalchemy.orm.exc import MultipleResultsFound
 
+from core.config import AccountMapping
 from core.config import settings
 from core.logs import MyLogger
 from core.util import convert_to_date
 from schemas.transactions import Transaction
 
 logger = MyLogger()
+
+CENTS = Decimal("0.01")
+
+
+def apply_topup(amount: Decimal, topup: int):
+    """Apply a Trade-Republic-style top-up to a spend amount.
+
+    The card is "topped up" in whole euros, so the amount actually leaving
+    the account is rounded up to the next euro, and the rounding remainder
+    is multiplied by the ``topup`` factor::
+
+        remainder = ceil(|amount|) - |amount|
+        if remainder > 0:  total = |amount| + topup * remainder
+        else (whole euro): total = |amount| + topup
+
+    Examples (topup = 1): 1.00 -> 2.00, 1.20 -> 2.00, 2.30 -> 3.00.
+    Examples (topup = 2): 1.00 -> 3.00, 1.20 -> 2.80, 2.30 -> 3.70.
+
+    The sign of ``amount`` is preserved (spends arrive negative). Returns a
+    ``(new_amount, note_suffix)`` tuple; ``note_suffix`` is empty when no
+    top-up was applied.
+    """
+    if not topup or topup <= 0:
+        return amount, ""
+
+    sign = Decimal(-1) if amount < 0 else Decimal(1)
+    base = abs(amount)
+    ceiled = base.to_integral_value(rounding=ROUND_CEILING)
+    remainder = ceiled - base
+
+    if remainder > 0:
+        total = base + (Decimal(topup) * remainder)
+    else:
+        total = base + Decimal(topup)
+
+    total = total.quantize(CENTS, rounding=ROUND_HALF_UP)
+    new_amount = sign * total
+
+    note_suffix = f"[topup {topup}x: orig {base.quantize(CENTS)} -> {total}]"
+    return new_amount, note_suffix
 
 
 class ActualService:
@@ -53,95 +97,158 @@ class ActualService:
             return None
         return matching_payees[0]
 
+    @staticmethod
+    def _unpack_mapping(value):
+        """Return ``(account_id, topup)`` from any supported mapping value.
+
+        Handles plain UUID strings (legacy), ``AccountMapping`` objects and
+        raw dicts (used by some tests that assign settings directly).
+        """
+        if value is None:
+            return None, 0
+        if isinstance(value, str):
+            return value, 0
+        if isinstance(value, AccountMapping):
+            return value.account_id, value.topup
+        if isinstance(value, dict):
+            return value.get("account_id"), int(value.get("topup", 0) or 0)
+        return getattr(value, "account_id", None), int(getattr(value, "topup", 0) or 0)
+
+    @classmethod
+    def _resolve_route(cls, account_name: str):
+        """Resolve a Tap-to-Pay card name to ``(budget, account_id, topup)``.
+
+        The card is looked up in every budget's ``account_mappings``. If it
+        is not mapped anywhere, it falls back to the budget flagged
+        ``default: true`` and its ``default_account_id``. Returns
+        ``(None, None, 0)`` when nothing matches and there is no default.
+        """
+        budgets = getattr(settings, "budgets", None) or []
+        default_budget = None
+        for budget in budgets:
+            mappings = budget.account_mappings or {}
+            if account_name in mappings:
+                account_id, topup = cls._unpack_mapping(mappings[account_name])
+                return budget.name_or_sync_id, account_id, topup
+            if getattr(budget, "default", False):
+                default_budget = budget
+
+        if default_budget is not None:
+            return default_budget.name_or_sync_id, default_budget.default_account_id, 0
+
+        return None, None, 0
+
     def add_transactions(self, transactions: List[Transaction]):
         transaction_info_list = []
-        submitted_transactions = []
 
-        with Actual(
-            settings.actual_url,
-            password=settings.actual_password,
-            encryption_password=settings.actual_encryption_password,
-            file=settings.actual_budget,
-        ) as actual:
-            for tx in transactions:
-                # Map account name to Actual account ID
-                account_id = settings.account_mappings.get(tx.account, settings.actual_default_account_id)
-                if not account_id:
-                    raise ValueError(f"Account name '{tx.account}' is not mapped to an Actual Account ID.")
+        # Resolve routing for everything up-front so an unmapped account
+        # fails fast, before any budget is opened.
+        routed = []  # (tx, budget, account_id, topup)
+        for tx in transactions:
+            budget, account_id, topup = self._resolve_route(tx.account)
+            if not account_id:
+                raise ValueError(f"Account name '{tx.account}' is not mapped to an Actual Account ID.")
+            routed.append((tx, budget, account_id, topup))
 
-                # Convert date and generate deterministic import ID
-                date = convert_to_date(tx.date)
-                amount = tx.amount
+        # Group by target budget, preserving first-seen order.
+        groups: "OrderedDict[str, list]" = OrderedDict()
+        for item in routed:
+            groups.setdefault(item[1], []).append(item)
 
-                # Determine payee
-                payee = tx.payee or settings.actual_backup_payee
-                import_id = self._build_import_id(
-                    account_id=account_id,
-                    amount=amount,
-                    date=date,
-                    payee=payee,
-                    notes=tx.notes,
-                    cleared=tx.cleared,
-                )
+        for budget, items in groups.items():
+            submitted_transactions = []
 
-                # Prepare transaction info for logging
-                transaction_info = {
-                    "Account": tx.account,
-                    "Account_ID": account_id,
-                    "Amount": str(amount),
-                    "Date": str(date),
-                    "Imported ID": import_id,
-                    "Payee": payee,
-                    "Notes": tx.notes,
-                    "Cleared": tx.cleared,
-                }
-                transaction_info_list.append(transaction_info)
+            with Actual(
+                settings.actual_url,
+                password=settings.actual_password,
+                encryption_password=settings.actual_encryption_password,
+                file=budget,
+            ) as actual:
+                for tx, _budget, account_id, topup in items:
+                    # Convert date
+                    date = convert_to_date(tx.date)
 
-                # Create transaction in Actual
-                try:
-                    actual_transaction = create_transaction(
-                        s=actual.session,
-                        account=account_id,
+                    # Apply per-account top-up (no-op when topup == 0)
+                    amount, note_suffix = apply_topup(tx.amount, topup)
+
+                    # Determine payee
+                    payee = tx.payee or settings.actual_backup_payee
+
+                    # Preserve the original amount in the notes when topped up
+                    notes = tx.notes
+                    if note_suffix:
+                        notes = f"{notes} {note_suffix}".strip() if notes else note_suffix
+
+                    import_id = self._build_import_id(
+                        account_id=account_id,
                         amount=amount,
                         date=date,
-                        imported_id=import_id,
                         payee=payee,
-                        notes=tx.notes,
+                        notes=notes,
                         cleared=tx.cleared,
-                        imported_payee=payee,
                     )
-                except Exception as error:
-                    if not self._is_duplicate_payee_error(error):
-                        raise
 
-                    fallback_payee = self._get_first_matching_payee(actual.session, payee)
-                    if fallback_payee is None:
-                        raise
+                    # Prepare transaction info for logging
+                    transaction_info = {
+                        "Account": tx.account,
+                        "Account_ID": account_id,
+                        "Budget": budget,
+                        "Amount": str(amount),
+                        "Original_Amount": str(tx.amount),
+                        "Topup": topup,
+                        "Date": str(date),
+                        "Imported ID": import_id,
+                        "Payee": payee,
+                        "Notes": notes,
+                        "Cleared": tx.cleared,
+                    }
+                    transaction_info_list.append(transaction_info)
 
-                    logger.warning(f"Duplicate payee match detected for '{payee}'. Falling back to first matching payee row.")
+                    # Create transaction in Actual
+                    try:
+                        actual_transaction = create_transaction(
+                            s=actual.session,
+                            account=account_id,
+                            amount=amount,
+                            date=date,
+                            imported_id=import_id,
+                            payee=payee,
+                            notes=notes,
+                            cleared=tx.cleared,
+                            imported_payee=payee,
+                        )
+                    except Exception as error:
+                        if not self._is_duplicate_payee_error(error):
+                            raise
 
-                    actual_transaction = create_transaction(
-                        s=actual.session,
-                        account=account_id,
-                        amount=amount,
-                        date=date,
-                        imported_id=import_id,
-                        payee=fallback_payee,
-                        notes=tx.notes,
-                        cleared=tx.cleared,
-                        imported_payee=payee,
-                    )
-                submitted_transactions.append(actual_transaction)
+                        fallback_payee = self._get_first_matching_payee(actual.session, payee)
+                        if fallback_payee is None:
+                            raise
 
-            # Run ruleset on submitted transactions
-            rs = get_ruleset(actual.session)
-            rs.run(submitted_transactions)
+                        logger.warning(f"Duplicate payee match detected for '{payee}'. Falling back to first matching payee row.")
 
-            # Log transaction info
-            logger.info("\n" + json.dumps(transaction_info_list, indent=2))
+                        actual_transaction = create_transaction(
+                            s=actual.session,
+                            account=account_id,
+                            amount=amount,
+                            date=date,
+                            imported_id=import_id,
+                            payee=fallback_payee,
+                            notes=notes,
+                            cleared=tx.cleared,
+                            imported_payee=payee,
+                        )
+                    submitted_transactions.append(actual_transaction)
 
-            # Commit changes
-            actual.commit()
+                # Run ruleset on submitted transactions
+                rs = get_ruleset(actual.session)
+                rs.run(submitted_transactions)
+
+                # Commit changes for this budget
+                actual.commit()
+
+        # Log transaction info
+        logger.info("\n" + json.dumps(transaction_info_list, indent=2))
 
         return transaction_info_list
 

--- a/tests/test_actual_service.py
+++ b/tests/test_actual_service.py
@@ -16,9 +16,10 @@ class TestActualService(unittest.TestCase):
         self.service = ActualService()
 
     @patch("services.actual_service.get_ruleset")
+    @patch.object(ActualService, "_find_existing_by_imported_id", return_value=None)
     @patch("services.actual_service.create_transaction")
     @patch("services.actual_service.Actual")
-    def test_add_transactions_success(self, mock_actual, mock_create_transaction, mock_get_ruleset):
+    def test_add_transactions_success(self, mock_actual, mock_create_transaction, mock_find_existing, mock_get_ruleset):
         # Arrange
         mock_actual_instance = MagicMock()
         mock_actual.return_value.__enter__.return_value = mock_actual_instance
@@ -101,7 +102,6 @@ class TestActualService(unittest.TestCase):
             amount=Transaction(account="A", amount="10.00").amount,
             date=date(2023, 1, 1),
             payee=" McDONALDS #2322 ",
-            notes=" Lunch ",
             cleared=False,
         )
 
@@ -110,19 +110,32 @@ class TestActualService(unittest.TestCase):
             amount=Transaction(account="A", amount="10").amount,
             date=date(2023, 1, 1),
             payee="mcdonalds #2322",
-            notes="lunch",
             cleared=False,
         )
 
         self.assertEqual(import_id_one, import_id_two)
         self.assertTrue(import_id_one.startswith("ID-"))
 
+    def test_build_import_id_ignores_notes(self):
+        common_args = dict(
+            account_id="actual-account-id",
+            amount=Transaction(account="A", amount="10.00").amount,
+            date=date(2023, 1, 1),
+            payee="McDonalds",
+            cleared=False,
+        )
+        self.assertEqual(
+            self.service._build_import_id(**common_args),
+            self.service._build_import_id(**common_args),
+        )
+
     @patch("services.actual_service.get_ruleset")
     @patch("services.actual_service.get_payees")
+    @patch.object(ActualService, "_find_existing_by_imported_id", return_value=None)
     @patch("services.actual_service.create_transaction")
     @patch("services.actual_service.Actual")
     def test_add_transactions_duplicate_payee_fallback(
-        self, mock_actual, mock_create_transaction, mock_get_payees, mock_get_ruleset
+        self, mock_actual, mock_create_transaction, mock_find_existing, mock_get_payees, mock_get_ruleset
     ):
         # Arrange
         mock_actual_instance = MagicMock()
@@ -181,10 +194,11 @@ class TestActualService(unittest.TestCase):
         mock_actual_instance.commit.assert_called_once()
 
     @patch("services.actual_service.get_ruleset")
+    @patch.object(ActualService, "_find_existing_by_imported_id", return_value=None)
     @patch("services.actual_service.create_transaction")
     @patch("services.actual_service.Actual")
     def test_add_transactions_uses_stable_import_id_for_replayed_transaction(
-        self, mock_actual, mock_create_transaction, mock_get_ruleset
+        self, mock_actual, mock_create_transaction, mock_find_existing, mock_get_ruleset
     ):
         mock_actual_instance = MagicMock()
         mock_actual.return_value.__enter__.return_value = mock_actual_instance
@@ -217,3 +231,41 @@ class TestActualService(unittest.TestCase):
         first_import_id = mock_create_transaction.call_args_list[0].kwargs["imported_id"]
         second_import_id = mock_create_transaction.call_args_list[1].kwargs["imported_id"]
         self.assertEqual(first_import_id, second_import_id)
+
+    @patch("services.actual_service.get_ruleset")
+    @patch.object(ActualService, "_find_existing_by_imported_id")
+    @patch("services.actual_service.create_transaction")
+    @patch("services.actual_service.Actual")
+    def test_add_transactions_skips_when_imported_id_already_exists(
+        self, mock_actual, mock_create_transaction, mock_find_existing, mock_get_ruleset
+    ):
+        mock_actual.return_value.__enter__.return_value = MagicMock()
+        mock_get_ruleset.return_value = MagicMock()
+        # Pretend a previous POST already inserted this transaction.
+        mock_find_existing.return_value = MagicMock(id="existing-tx-id")
+
+        settings.budgets = [
+            BudgetConfig(
+                name_or_sync_id="Main",
+                default=True,
+                default_account_id="default-account-id",
+                account_mappings={"Test Account": "actual-account-id"},
+            )
+        ]
+        settings.actual_backup_payee = "Backup Payee"
+
+        result = self.service.add_transactions(
+            [
+                Transaction(
+                    account="Test Account",
+                    date="2023-01-01",
+                    amount="10.00",
+                    payee="McDonalds",
+                    cleared=True,
+                )
+            ]
+        )
+
+        mock_create_transaction.assert_not_called()
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0]["Deduped"])

--- a/tests/test_actual_service.py
+++ b/tests/test_actual_service.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from sqlalchemy.orm.exc import MultipleResultsFound
 
+from core.config import BudgetConfig
 from core.config import settings
 from schemas.transactions import Transaction
 from services.actual_service import ActualService
@@ -43,8 +44,14 @@ class TestActualService(unittest.TestCase):
             ),
         ]
 
-        settings.account_mappings = {"Test Account": "actual-account-id"}
-        settings.actual_default_account_id = "default-account-id"
+        settings.budgets = [
+            BudgetConfig(
+                name_or_sync_id="Main",
+                default=True,
+                default_account_id="default-account-id",
+                account_mappings={"Test Account": "actual-account-id"},
+            )
+        ]
         settings.actual_backup_payee = "Backup Payee"
 
         # Act
@@ -82,8 +89,7 @@ class TestActualService(unittest.TestCase):
                 cleared=True,
             )
         ]
-        settings.account_mappings = {}
-        settings.actual_default_account_id = None
+        settings.budgets = [BudgetConfig(name_or_sync_id="Main", account_mappings={})]
 
         # Act & Assert
         with self.assertRaises(ValueError):
@@ -144,8 +150,14 @@ class TestActualService(unittest.TestCase):
             )
         ]
 
-        settings.account_mappings = {"Test Account": "actual-account-id"}
-        settings.actual_default_account_id = "default-account-id"
+        settings.budgets = [
+            BudgetConfig(
+                name_or_sync_id="Main",
+                default=True,
+                default_account_id="default-account-id",
+                account_mappings={"Test Account": "actual-account-id"},
+            )
+        ]
         settings.actual_backup_payee = "Backup Payee"
 
         # Act
@@ -179,8 +191,14 @@ class TestActualService(unittest.TestCase):
         mock_ruleset = MagicMock()
         mock_get_ruleset.return_value = mock_ruleset
 
-        settings.account_mappings = {"Test Account": "actual-account-id"}
-        settings.actual_default_account_id = "default-account-id"
+        settings.budgets = [
+            BudgetConfig(
+                name_or_sync_id="Main",
+                default=True,
+                default_account_id="default-account-id",
+                account_mappings={"Test Account": "actual-account-id"},
+            )
+        ]
         settings.actual_backup_payee = "Backup Payee"
 
         tx = Transaction(

--- a/tests/test_topup_and_budgets.py
+++ b/tests/test_topup_and_budgets.py
@@ -1,0 +1,183 @@
+import unittest
+from decimal import Decimal
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from core.config import BudgetConfig
+from schemas.transactions import Transaction
+from services.actual_service import ActualService
+from services.actual_service import apply_topup
+
+
+class TestApplyTopup(unittest.TestCase):
+    def test_topup_disabled_is_noop(self):
+        amount, note = apply_topup(Decimal("-1.20"), 0)
+        self.assertEqual(amount, Decimal("-1.20"))
+        self.assertEqual(note, "")
+
+    def test_topup_1x(self):
+        cases = {
+            "1.00": "2.00",
+            "1.20": "2.00",
+            "2.30": "3.00",
+            "7.50": "8.00",
+        }
+        for original, expected in cases.items():
+            amount, note = apply_topup(Decimal(original), 1)
+            self.assertEqual(amount, Decimal(expected), f"1x {original}")
+            self.assertIn("topup 1x", note)
+
+    def test_topup_2x(self):
+        cases = {
+            "1.00": "3.00",
+            "1.20": "2.80",
+            "2.30": "3.70",
+            "7.50": "8.50",
+        }
+        for original, expected in cases.items():
+            amount, _ = apply_topup(Decimal(original), 2)
+            self.assertEqual(amount, Decimal(expected), f"2x {original}")
+
+    def test_topup_preserves_negative_sign(self):
+        # Spends arrive negative after the API inverts them.
+        amount, note = apply_topup(Decimal("-1.20"), 1)
+        self.assertEqual(amount, Decimal("-2.00"))
+        self.assertIn("orig 1.20 -> 2.00", note)
+
+
+class TestResolveRoute(unittest.TestCase):
+    @patch("services.actual_service.settings")
+    def test_string_mapping(self, mock_settings):
+        mock_settings.budgets = [
+            BudgetConfig(name_or_sync_id="Main", account_mappings={"Card A": "uuid-a"}),
+        ]
+        self.assertEqual(ActualService._resolve_route("Card A"), ("Main", "uuid-a", 0))
+
+    @patch("services.actual_service.settings")
+    def test_object_mapping_with_topup(self, mock_settings):
+        mock_settings.budgets = [
+            BudgetConfig(
+                name_or_sync_id="Main",
+                account_mappings={"TR": {"account_id": "uuid-tr", "topup": 2}},
+            ),
+        ]
+        self.assertEqual(ActualService._resolve_route("TR"), ("Main", "uuid-tr", 2))
+
+    @patch("services.actual_service.settings")
+    def test_default_budget_fallback(self, mock_settings):
+        mock_settings.budgets = [
+            BudgetConfig(name_or_sync_id="Other", account_mappings={"Card B": "uuid-b"}),
+            BudgetConfig(
+                name_or_sync_id="Main",
+                default=True,
+                default_account_id="default-id",
+                account_mappings={"Card A": "uuid-a"},
+            ),
+        ]
+        self.assertEqual(ActualService._resolve_route("Unknown"), ("Main", "default-id", 0))
+
+    @patch("services.actual_service.settings")
+    def test_no_match_no_default_returns_none(self, mock_settings):
+        mock_settings.budgets = [
+            BudgetConfig(name_or_sync_id="Main", account_mappings={"Card A": "uuid-a"}),
+        ]
+        self.assertEqual(ActualService._resolve_route("Unknown"), (None, None, 0))
+
+    @patch("services.actual_service.settings")
+    def test_routes_card_to_its_budget(self, mock_settings):
+        mock_settings.budgets = [
+            BudgetConfig(
+                name_or_sync_id="sync-1",
+                default=True,
+                default_account_id="def-1",
+                account_mappings={"Card A": {"account_id": "uuid-a", "topup": 1}},
+            ),
+            BudgetConfig(name_or_sync_id="sync-2", account_mappings={"Card B": "uuid-b"}),
+        ]
+        self.assertEqual(ActualService._resolve_route("Card A"), ("sync-1", "uuid-a", 1))
+        self.assertEqual(ActualService._resolve_route("Card B"), ("sync-2", "uuid-b", 0))
+        self.assertEqual(ActualService._resolve_route("Card C"), ("sync-1", "def-1", 0))
+
+
+class TestAddTransactionsMultiBudget(unittest.TestCase):
+    @patch("services.actual_service.get_ruleset")
+    @patch("services.actual_service.create_transaction")
+    @patch("services.actual_service.Actual")
+    @patch("services.actual_service.settings")
+    def test_transactions_split_across_budgets(self, mock_settings, mock_actual, mock_create_transaction, mock_get_ruleset):
+        mock_settings.actual_url = "http://x"
+        mock_settings.actual_password = "p"
+        mock_settings.actual_encryption_password = None
+        mock_settings.actual_backup_payee = "Unknown"
+        mock_settings.budgets = [
+            BudgetConfig(name_or_sync_id="sync-1", account_mappings={"Card A": "uuid-a"}),
+            BudgetConfig(name_or_sync_id="sync-2", account_mappings={"Card B": "uuid-b"}),
+        ]
+
+        mock_actual.return_value.__enter__.return_value = MagicMock()
+        mock_get_ruleset.return_value = MagicMock()
+
+        service = ActualService()
+        result = service.add_transactions(
+            [
+                Transaction(account="Card A", date="2023-01-01", amount="10.00", payee="P1"),
+                Transaction(account="Card B", date="2023-01-02", amount="20.00", payee="P2"),
+            ]
+        )
+
+        # One Actual context opened per distinct budget
+        opened_files = {call.kwargs["file"] for call in mock_actual.call_args_list}
+        self.assertEqual(opened_files, {"sync-1", "sync-2"})
+        self.assertEqual(len(result), 2)
+        self.assertEqual({r["Budget"] for r in result}, {"sync-1", "sync-2"})
+
+    @patch("services.actual_service.get_ruleset")
+    @patch("services.actual_service.create_transaction")
+    @patch("services.actual_service.Actual")
+    @patch("services.actual_service.settings")
+    def test_topup_applied_and_noted(self, mock_settings, mock_actual, mock_create_transaction, mock_get_ruleset):
+        mock_settings.actual_url = "http://x"
+        mock_settings.actual_password = "p"
+        mock_settings.actual_encryption_password = None
+        mock_settings.actual_backup_payee = "Unknown"
+        mock_settings.budgets = [
+            BudgetConfig(
+                name_or_sync_id="Main",
+                account_mappings={"TR": {"account_id": "uuid-tr", "topup": 1}},
+            ),
+        ]
+
+        mock_actual.return_value.__enter__.return_value = MagicMock()
+        mock_get_ruleset.return_value = MagicMock()
+
+        service = ActualService()
+        result = service.add_transactions(
+            [Transaction(account="TR", date="2023-01-01", amount="-1.20", payee="Shop", notes="lunch")]
+        )
+
+        self.assertEqual(result[0]["Amount"], "-2.00")
+        self.assertEqual(result[0]["Original_Amount"], "-1.20")
+        self.assertEqual(result[0]["Topup"], 1)
+        self.assertIn("topup 1x", result[0]["Notes"])
+        self.assertTrue(result[0]["Notes"].startswith("lunch "))
+        passed_amount = mock_create_transaction.call_args_list[0].kwargs["amount"]
+        self.assertEqual(passed_amount, Decimal("-2.00"))
+
+    @patch("services.actual_service.Actual")
+    @patch("services.actual_service.settings")
+    def test_unmapped_account_without_default_raises(self, mock_settings, mock_actual):
+        mock_settings.actual_url = "http://x"
+        mock_settings.actual_password = "p"
+        mock_settings.actual_encryption_password = None
+        mock_settings.actual_backup_payee = "Unknown"
+        mock_settings.budgets = [
+            BudgetConfig(name_or_sync_id="Main", account_mappings={"Card A": "uuid-a"}),
+        ]
+        mock_actual.return_value.__enter__.return_value = MagicMock()
+
+        with self.assertRaises(ValueError):
+            ActualService().add_transactions([Transaction(account="Nope", date="2023-01-01", amount="1.00")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_topup_and_budgets.py
+++ b/tests/test_topup_and_budgets.py
@@ -101,10 +101,13 @@ class TestResolveRoute(unittest.TestCase):
 
 class TestAddTransactionsMultiBudget(unittest.TestCase):
     @patch("services.actual_service.get_ruleset")
+    @patch.object(ActualService, "_find_existing_by_imported_id", return_value=None)
     @patch("services.actual_service.create_transaction")
     @patch("services.actual_service.Actual")
     @patch("services.actual_service.settings")
-    def test_transactions_split_across_budgets(self, mock_settings, mock_actual, mock_create_transaction, mock_get_ruleset):
+    def test_transactions_split_across_budgets(
+        self, mock_settings, mock_actual, mock_create_transaction, mock_find_existing, mock_get_ruleset
+    ):
         mock_settings.actual_url = "http://x"
         mock_settings.actual_password = "p"
         mock_settings.actual_encryption_password = None
@@ -132,10 +135,13 @@ class TestAddTransactionsMultiBudget(unittest.TestCase):
         self.assertEqual({r["Budget"] for r in result}, {"sync-1", "sync-2"})
 
     @patch("services.actual_service.get_ruleset")
+    @patch.object(ActualService, "_find_existing_by_imported_id", return_value=None)
     @patch("services.actual_service.create_transaction")
     @patch("services.actual_service.Actual")
     @patch("services.actual_service.settings")
-    def test_topup_applied_and_noted(self, mock_settings, mock_actual, mock_create_transaction, mock_get_ruleset):
+    def test_topup_applied_and_noted(
+        self, mock_settings, mock_actual, mock_create_transaction, mock_find_existing, mock_get_ruleset
+    ):
         mock_settings.actual_url = "http://x"
         mock_settings.actual_password = "p"
         mock_settings.actual_encryption_password = None


### PR DESCRIPTION
## Summary

This PR replaces the flat, single-budget configuration with a single `budgets:` list and adds an opt-in, per-account **top-up** that mirrors how Trade Republic style top-up cards actually deduct money.

Two capabilities, one cohesive config:

1. **Multiple budgets / Sync IDs** — the card used for a payment decides which budget is opened, so transactions are routed across budgets automatically.
2. **Per-account top-up** — for cards that are "topped up" in whole euros, the amount recorded in Actual reflects what actually leaves the account.

## Motivation

- Users who keep more than one Actual budget (e.g. personal + shared) previously had no way to route different cards to different budgets/Sync IDs.
- Top-up cards (Trade Republic, etc.) deduct a rounded-up amount: a €1.20 spend really removes €2.00. Recording the raw amount made those budgets drift from reality.
- The previous design exposed *two* overlapping mechanisms (`actual_budget` + flat `account_mappings`). This unifies everything into one structure so there is exactly one way to configure routing.

## Configuration

```yaml
budgets:
  - name_or_sync_id: "My budget"
    default: true                                # absorbs unmapped cards
    default_account_id: "8AF657D4-4811-42C7-8272-E299A8DAC43A"
    account_mappings:
      "Personal Card": "b15d14ce-c0d0-40a8-95ac-45fc6681f420"   # short form
      "Trade Republic":
        account_id: "D4E9A36B-1C8E-4D2A-9F6B-1A2B3C4D5E6F"      # explicit form
        topup: 1
  - name_or_sync_id: "Shared budget"
    account_mappings:
      "Joint Card": "C3D8F25A-9C7D-4C9B-8589-8A3790C03B2D"
```

- A card is looked up in every budget's `account_mappings`; if unmapped it falls back to the budget flagged `default: true` and its `default_account_id`.
- Validation enforces a non-empty `budgets` list, at most one `default: true` budget, and that the default budget defines `default_account_id`.
- Transactions are grouped by target budget; each budget is opened, written and committed in its own `Actual` context.

## Top-up math

For an account with `topup: N`, the recorded spend is:

- `remainder = ceil(|amount|) - |amount|`
- if `remainder > 0`: `total = |amount| + N * remainder`
- if the amount is a whole euro: `total = |amount| + N`

The sign is preserved (spends arrive negative) and the original amount is kept in the transaction notes, e.g. `lunch [topup 1x: orig 1.20 -> 2.00]`.

| Amount | topup 1 | topup 2 | topup 3 |
| ------ | ------- | ------- | ------- |
| 1.00   | 2.00    | 3.00    | 4.00    |
| 1.20   | 2.00    | 2.80    | 3.60    |
| 2.30   | 3.00    | 3.70    | 4.40    |
| 7.50   | 8.00    | 8.50    | 9.00    |

`topup: 0` (or the short string form) disables it.

## Breaking change & migration

The legacy keys `actual_budget`, `actual_default_account_id` and the top-level `account_mappings` are **removed**. Migrate:

```yaml
# before
actual_budget: "My budget"
actual_default_account_id: "8AF657D4-..."
account_mappings:
  "Card": "uuid"

# after
budgets:
  - name_or_sync_id: "My budget"
    default: true
    default_account_id: "8AF657D4-..."
    account_mappings:
      "Card": "uuid"
```

## Testing

- `pytest`: **80 passed** (added `tests/test_topup_and_budgets.py` covering top-up math, sign handling, card→budget routing, the multi-budget split and the unmapped/no-default error; existing service tests updated to the new schema).
- pre-commit (isort/black/flake8) clean on changed files.
- `config/config.yml.sample` updated so CI's `cp config.yml.sample config.yml` step yields a valid configuration.

## Commits

- `feat(config,services): single budgets schema with per-account top-up`
- `docs(config): document budgets list and per-account top-up`

## Real QA Examples

Request:

<img width="519" height="691" alt="image" src="https://github.com/user-attachments/assets/661b015f-25a9-4e32-bf0b-7e90078f6866" />

Primary budget with topup:

<img width="1359" height="104" alt="image" src="https://github.com/user-attachments/assets/bf1a2d1f-c0bd-4e86-883b-98f03e7b61d1" />

Different budget:

<img width="1439" height="110" alt="image" src="https://github.com/user-attachments/assets/790eccb0-5e26-4de5-8c15-013f80171cf7" />

